### PR TITLE
inhibit suspend,idle for video and suspend for audio

### DIFF
--- a/.ccls
+++ b/.ccls
@@ -1,3 +1,4 @@
 %compile_commands.json
+-Iinclude
 -I/usr/include/dbus-1.0
 -I/usr/lib/dbus-1.0/include

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Plugin Release
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev
+          make
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./lib/mpv_inhibit_gnome.so
+          asset_name: mpv_inhibit_gnome.so
+          asset_content_type: application/x-sharedlib

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .ccls-cache
-bin/*
-*.o
+lib
+build
+include

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET = lib/mpv_inhibit_gnome.so
 SRC_DIR = src
 
-C_FLAGS = -Wall -g -fPIC -I./include/ $(shell pkg-config --libs --cflags dbus-1)
+C_FLAGS = -Wall -g -fPIC -Iinclude $(shell pkg-config --libs --cflags dbus-1)
 
 SRCS := $(shell find $(SRC_DIR) -name *.c)
 OBJS := $(patsubst src/%.c,build/%.o,$(SRCS))

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ GNOME supports the standard inhibition protocol
 ([yet](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/111)).
 
 ## Install
-Depends on library: `libdbus-1` (Arch: `dbus`, Fedora: `dbus-devel`)
+The library `libdbus-1` is needed (Arch: `dbus`, Fedora: `dbus-devel`, Ubuntu: `libdbus-1-dev`).
+
 Install copies `lib/mpv_inhibit_gnome.so` to mpv scripts directory:
 ```bash
 # install for user: ~/.config/mpv/scripts

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ This is needed because neither mpv supports GNOME's inhibition protocol, nor
 GNOME supports the standard inhibition protocol
 ([yet](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/111)).
 
-## Manually building and installing
-
-The library `libdbus-1` is needed. In Arch Linux it's provided by the package
-`dbus`.
-
-Running `make` generates a file called `mpv_inhibit_gnome.so` inside the `bin`
-directory.
-Copy this file into your mpv scripts directory
-(per user: `~/.config/mpv/scripts` or globally: `/usr/share/mpv/scripts/`).
+## Install
+Depends on library: `libdbus-1` (Arch: `dbus`, Fedora: `dbus-devel`)
+Install copies `lib/mpv_inhibit_gnome.so` to mpv scripts directory:
+```bash
+# install for user: ~/.config/mpv/scripts
+make install
+# or install for flatpak: ~/.var/app/io.mpv.Mpv/config/mpv/scripts
+# flatpak override --user --talk-name=org.gnome.SessionManager io.mpv.Mpv
+make flatpak-install flatpakoverride
+# or install for system: /usr/share/mpv/scripts
+sudo make sys-install
+```

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,4 +1,6 @@
 -I
+include
+-I
 /usr/include/dbus-1.0
 -I
 /usr/lib/dbus-1.0/include

--- a/src/main.c
+++ b/src/main.c
@@ -6,17 +6,34 @@
 
 #include "gnome_session_manager.h"
 
+#define FLAG_PROP_COUNT 7
+
+typedef struct __attribute__((packed)) {
+	bool pause;
+	bool idle_active;
+	bool stop_screensaver;
+	bool window_minimized;
+	bool mute;
+	bool vid;
+	bool aid;
+} PropsFlags;
+
+typedef union {
+	PropsFlags flags;
+	bool values[FLAG_PROP_COUNT];
+} Props;
+
+
 typedef struct {
 	// handles
 	mpv_handle *handle;
 	GSM *gsm;
 
-	// config options
-	bool enable;
+	// active inhibition flags
+	uint32_t flags;
 
-	// mpv status
-	bool pause;
-	bool idle_active;
+	// mpv props
+	Props props;
 } plugin_globals;
 
 void show_text(mpv_handle *handle, const char *text)
@@ -27,35 +44,65 @@ void show_text(mpv_handle *handle, const char *text)
 #endif
 }
 
-void begin_inhibit(plugin_globals *globals)
-{
-	if(!globals->enable)
-		return;
-
-	show_text(globals->handle, "Starting inhibit");
-	GSM_inhibit(globals->gsm, "mpv", "Media is playing", GSM_INHIBIT_IDLE);
-}
-void end_inhibit(plugin_globals *globals)
-{
-	if(!globals->enable)
-		return;
-
-	show_text(globals->handle, "Stopping inhibit");
-	GSM_uninhibit(globals->gsm);
-}
-
 void init_globals(plugin_globals *globals)
 {
 	// handles
 	globals->gsm    = NULL;
 	globals->handle = NULL;
 
-	// config options
-	globals->enable = false;
+	globals->flags = 0;
+	// mpv props
+	globals->props.flags = (PropsFlags){
+	    // True if paused
+	    .pause = true,
+	    // If true, no file is loaded
+	    // We need to check this property because `pause` may be false while no
+	    // media is being played and `--idle` is specified
+	    .idle_active = false,
+	    // If false, disable inhibition
+	    .stop_screensaver = false,
+	    // If playing audio minimized, only inhibit suspend
+	    .window_minimized = false,
+	    // No inhibition if no audio and no video
+	    .mute = false,
+	    .vid  = false,
+	    .aid  = false};
+}
 
-	// mpv status
-	globals->pause       = true;
-	globals->idle_active = false;
+
+void update_prop(plugin_globals *globals, unsigned prop_index, bool value)
+{
+	globals->props.values[prop_index] = value;
+	PropsFlags props                  = globals->props.flags;
+
+	bool visually_perceivable = props.vid && !props.window_minimized;
+	bool auditory_perceivable = props.aid && !props.mute;
+	bool playing_perceivable  = !(props.idle_active || props.pause)
+	                           && (auditory_perceivable || visually_perceivable);
+
+	bool inhibit_suspend = props.stop_screensaver && playing_perceivable;
+	bool inhibit_idle    = inhibit_suspend && visually_perceivable;
+
+	uint32_t new_flags = (inhibit_idle * GSM_INHIBIT_IDLE)
+	                     | (inhibit_suspend * GSM_INHIBIT_SUSPEND);
+
+	if(globals->flags != new_flags)
+	{
+		globals->flags = new_flags;
+		if(new_flags)
+		{
+			show_text(globals->handle,
+			          (inhibit_idle ? "Starting inhibit: idle,suspend"
+			                        : "Starting inhibit: suspend"));
+			GSM_inhibit(globals->gsm, "mpv",
+			            inhibit_idle ? "Playing video" : "Playing audio", new_flags);
+		}
+		else
+		{
+			show_text(globals->handle, "Stopping inhibit");
+			GSM_uninhibit(globals->gsm);
+		}
+	}
 }
 
 int mpv_open_cplugin(mpv_handle *handle)
@@ -71,94 +118,40 @@ int mpv_open_cplugin(mpv_handle *handle)
 		return -1; // Error while opening dbus
 	}
 
-	// If false disable inhibition
-	mpv_observe_property(globals.handle, 0, "stop-screensaver", MPV_FORMAT_FLAG);
+	const char *const flag_prop_names[FLAG_PROP_COUNT] = {
+	    "pause", "idle-active", "stop-screensaver", "window-minimized", "mute",
+	    "vid",   "aid",
+	};
+	for(unsigned i = 0; i < FLAG_PROP_COUNT; i++)
+	{
+		mpv_observe_property(globals.handle, 0, flag_prop_names[i],
+		                     i < FLAG_PROP_COUNT - 2 ? MPV_FORMAT_FLAG
+		                                             : MPV_FORMAT_INT64);
+	}
 
-	// Returns true if no file is loaded
-	// We need to check this property because `pause` may be false while no
-	// media is being played and `--idle` is specified
-	mpv_observe_property(globals.handle, 0, "idle-active", MPV_FORMAT_FLAG);
-
-	// True if paused
-	mpv_observe_property(globals.handle, 0, "pause", MPV_FORMAT_FLAG);
-
-	mpv_event *last_event    = NULL;
+	mpv_event *event         = NULL;
 	mpv_event_property *prop = NULL;
 	// Event loop
 	while(!done)
 	{
-		last_event = mpv_wait_event(handle, -1);
+		event = mpv_wait_event(handle, -1);
 
-		switch(last_event->event_id)
+		switch(event->event_id)
 		{
 			case MPV_EVENT_PROPERTY_CHANGE:
-				prop = last_event->data;
+				prop = event->data;
 
-				if(prop->format == MPV_FORMAT_FLAG)
+				if(prop->format == MPV_FORMAT_FLAG || prop->format == MPV_FORMAT_INT64)
 				{
-					if(strcmp(prop->name, "pause") == 0)
+					for(unsigned i = 0; i < FLAG_PROP_COUNT; i++)
 					{
-						globals.pause = *(int *)(prop->data);
-
-						// If `idle_active` is true, we are not really paused
-						if(!globals.idle_active)
+						if(strcmp(prop->name, flag_prop_names[i]) == 0)
 						{
-							if(!globals.pause)
-							{
-								begin_inhibit(&globals);
-							}
-							else
-							{
-								end_inhibit(&globals);
-							}
-						}
-					}
-					else if(strcmp(prop->name, "idle-active") == 0)
-					{
-						int old_idle_active = globals.idle_active;
-						globals.idle_active = *(int *)(prop->data);
-
-						if(!old_idle_active && globals.idle_active)
-						{
-							// The player became idle-active
-							if(!globals.pause) // Avoid ending inhibit uselessly
-							{
-								end_inhibit(&globals);
-							}
-						}
-						else if(old_idle_active && !globals.idle_active)
-						{
-							// The player stopped being idle-active
-							// so we follow the pause property
-							// We were already uninhibited, so only check if
-							// playing
-							if(!globals.pause)
-							{
-								begin_inhibit(&globals);
-							}
-						}
-					}
-					else if(strcmp(prop->name, "stop-screensaver") == 0)
-					{
-						int old_enable = globals.enable;
-						globals.enable = *(int *)(prop->data);
-
-						if(old_enable && !globals.enable)
-						{
-							// We got disabled, stop inhibition in any case
-							end_inhibit(&globals);
-						}
-						else if(!old_enable && globals.enable)
-						{
-							// We got enabled
-							if(!globals.pause && !globals.idle_active)
-							{
-								begin_inhibit(&globals);
-							}
+							update_prop(&globals, i, *(bool *)(prop->data));
+							break;
 						}
 					}
 				}
-
 				break;
 			case MPV_EVENT_SHUTDOWN: // quit
 				// Will automatically uninhibit


### PR DESCRIPTION
Hi,
still no movement on the gnome/mpv idle inhibit front, [yet](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/111) :upside_down_face:
I think your approach is better than using the `gnome-session-inhibit` tool.

Changes:
- if mpv is playing without (visible) video, It will only inhibit suspend and not idle (such that screen saver may activate while playing music)
- copy to mpv scripts dir with `make install`
- build release lib with `.github/workflows/release.yml`
