### PR TITLE
fix not linking to dbus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,18 @@ TARGET = lib/mpv_inhibit_gnome.so
 SRC_DIR = src
 XDG_CONFIG_DIR := $(or $(XDG_CONFIG_HOME),$(HOME)/.config)
 
-C_FLAGS = -Wall -g -fPIC $(shell pkg-config --libs --cflags dbus-1)
+C_FLAGS = -Wall -g $(shell pkg-config --libs --cflags dbus-1)
 
 SRCS := $(shell find $(SRC_DIR) -name *.c)
 OBJS := $(patsubst src/%.c,build/%.o,$(SRCS))
 
 $(TARGET): $(OBJS)
 	-@mkdir -p $(@D)
-	gcc -Wall -g -shared $^ -o $@
+	gcc $(C_FLAGS) -shared $^ -o $@
 
 build/%.o: src/%.c
 	-@mkdir -p $(@D)
-	gcc -c $(C_FLAGS) $< -o $@
+	gcc -c $(C_FLAGS) -fPIC $< -o $@
 
 define INSTALL_PLUGIN
 .PHONY: $(1) $(2)


### PR DESCRIPTION
I have been wondering why this did not cause problems before but `dbus` is not linked in the shared library.
#4 is also happening now for me (new mpv version). 

```
[mpv_inhibit_gnome] C plugin error: '/app/etc/mpv/scripts/mpv_inhibit_gnome.so: undefined symbol: dbus_bus_get'
[mpv_inhibit_gnome] Could not load SO plugin /app/etc/mpv/scripts/mpv_inhibit_gnome.so
```